### PR TITLE
営業目的のご連絡に関するポリシーページを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,6 +210,9 @@
     <div class="container text-center">
       <h2 class="mb-4">Contact</h2>
       <a class="btn btn-light btn-xl" href="https://forms.gle/swa8kjGTCskRL2gv9">お問い合わせ</a>
+      <p class="mt-4 mb-0">
+        <a class="text-white-50" href="sales-email-policy.html">営業目的のご連絡に関するポリシー</a>
+      </p>
     </div>
   </section>
 

--- a/sales-email-policy.html
+++ b/sales-email-policy.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="def合同会社の営業目的のご連絡に関するポリシー。お問い合わせフォームからの送信および公表メールアドレス宛ての営業目的の連絡の取扱いについて定めます。">
+  <meta name="author" content="def合同会社">
+
+  <title>営業目的のご連絡に関するポリシー | def.inc</title>
+
+  <!-- Font Awesome Icons -->
+  <link href="vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
+
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Merriweather+Sans:400,700" rel="stylesheet">
+  <link href='https://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700,700italic' rel='stylesheet' type='text/css'>
+
+  <!-- Plugin CSS -->
+  <link href="vendor/magnific-popup/magnific-popup.css" rel="stylesheet">
+
+  <!-- Theme CSS - Includes Bootstrap -->
+  <link href="css/creative.min.css" rel="stylesheet">
+
+  <style>
+    /* 規約ページ用の可読性調整 */
+    .policy-section {
+      padding-top: 9rem;
+    }
+    .policy-section h1 {
+      font-size: 2.25rem;
+    }
+    .policy-section h2 {
+      font-size: 1.4rem;
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+    }
+    .policy-section p,
+    .policy-section li {
+      line-height: 1.9;
+    }
+    .policy-meta {
+      color: #6c757d;
+      font-size: .9rem;
+    }
+    .policy-lead {
+      background-color: #f8f9fa;
+      border-left: 4px solid #f4623a;
+      padding: 1.25rem 1.5rem;
+      border-radius: .25rem;
+    }
+  </style>
+</head>
+
+<body id="page-top">
+  <!-- Navigation -->
+  <nav class="navbar navbar-expand-lg navbar-light fixed-top py-3" id="mainNav">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">def.inc</a>
+      <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarResponsive">
+        <ul class="navbar-nav ml-auto my-2 my-lg-0">
+          <li class="nav-item">
+            <a class="nav-link" href="index.html#about">About</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="index.html#services">Services</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="index.html#contact">Contact</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="index.html#info">Info</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Policy Section -->
+  <section class="page-section policy-section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-9">
+
+          <h1 class="mt-0">営業目的のご連絡に関するポリシー</h1>
+          <p class="policy-meta">最終更新日: 2026-05-18</p>
+          <hr class="divider my-4">
+
+          <p class="policy-lead mb-5">
+            本ポリシーは、def合同会社（以下「当社」といいます）への営業・勧誘等を目的とした連絡（以下「営業連絡」といいます）の取扱いについて定めるものです。本ポリシーは、当社が運営するウェブサイト de-f.net 上のお問い合わせフォーム（以下「本フォーム」といいます）から送信された連絡と、当社が公開しているメールアドレス（以下「公表メールアドレス」といいます）宛てに送信された連絡の双方に適用されます。
+          </p>
+
+          <h2>第1条（方針）</h2>
+          <p>本フォームは、お客様からのお問い合わせを受け付けるための専用窓口です。当社は開発・運用業務に集中するため、無断の営業連絡をお断りしています。営業目的の送信にはお返事いたしません。</p>
+
+          <h2>第2条（営業連絡の定義）</h2>
+          <p>本ポリシーにおいて「営業連絡」とは、送信者（またはその所属組織）の商品・サービス・人材・コンテンツ等を、当社に対して購入・利用・受託・採用・提携等の形で受領するよう促す連絡をいいます。具体的には、次のような連絡が該当します。</p>
+          <ul>
+            <li>営業・勧誘・広告掲載のご案内</li>
+            <li>SEO対策・リスティング広告運用・Web制作等の代行サービスのご提案</li>
+            <li>人材紹介・採用支援・業務委託・営業代行のご提案</li>
+            <li>M&A仲介・システム提案・各種ソリューションのご提案</li>
+            <li>その他、自社の商品・サービス等の購入・利用・提携を促す内容を含む連絡</li>
+          </ul>
+
+          <h2>第3条（お問い合わせフォーム利用時のお願い）</h2>
+          <p>本フォームをご利用の際は、次の点にご協力ください。</p>
+          <ul>
+            <li>営業目的の送信はご遠慮ください。</li>
+            <li>フォーム内の必須項目「本問い合わせは営業・勧誘目的ではありません」には、正確にご回答ください。営業・勧誘を目的とする送信の場合は「いいえ」をお選びください。</li>
+            <li>「はい」を選択しながら営業連絡を送信された場合、その回答内容と矛盾する送信として取り扱い、お返事はいたしません。</li>
+          </ul>
+
+          <h2>第4条（公表メールアドレス宛ての送信）</h2>
+          <p>公表メールアドレスは、業務上必要な連絡（取材、採用応募、既存のお取引先からのご連絡、公務連絡、協業のご相談等）を受け付けるために公開しているものです。本フォームを経由せず公表メールアドレス宛てに送信された営業連絡についても、本フォーム経由の場合と同様にお断りし、お返事はいたしません。</p>
+
+          <h2>第5条（無断営業連絡への対応）</h2>
+          <p>無断の営業連絡を受信した場合、当社は次の対応をとることがあります。</p>
+          <ul>
+            <li>当該連絡への返信を行わないこと</li>
+            <li>当該送信者のメールアドレスおよびドメインからの受信を拒否すること</li>
+            <li>悪質・反復的な送信について、関連法令（特定電子メールの送信の適正化等に関する法律等）に基づき必要な措置を検討すること</li>
+          </ul>
+
+          <h2>第6条（適用除外）</h2>
+          <p>以下の連絡は、営業連絡には該当しないものとして取り扱います。</p>
+          <ul>
+            <li>報道機関等によるメディア取材・講演依頼</li>
+            <li>当社が募集している人材・委託先への応募・推薦</li>
+            <li>当社と既にお取引のある法人・個人からの業務上のご連絡</li>
+            <li>国・地方公共団体・公益法人等からの公務目的のご連絡</li>
+            <li>当社の事業内容に具体的に言及し、当社を個別の宛先として作成された協業・提携のご相談</li>
+          </ul>
+
+          <h2>第7条（個人情報の取扱い）</h2>
+          <p>営業連絡の受信に伴って取得した個人情報を含む、お問い合わせを通じて取得した個人情報の取扱いは、当社のプライバシーポリシーに従います。</p>
+
+          <h2>第8条（本ポリシーの変更）</h2>
+          <p>当社は、本ポリシーを必要に応じて変更することがあります。変更後の内容は、本サイトに掲載した時点から適用されるものとします。</p>
+
+          <hr class="divider my-5">
+          <p class="text-center">
+            <a class="btn btn-primary" href="index.html">トップページへ戻る</a>
+          </p>
+
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="bg-light py-5">
+    <div class="container">
+      <div class="small text-center text-muted">Copyright &copy; 2019 - def.inc</div>
+    </div>
+  </footer>
+
+  <!-- Bootstrap core JavaScript -->
+  <script src="vendor/jquery/jquery.min.js"></script>
+  <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+
+  <!-- Plugin JavaScript -->
+  <script src="vendor/jquery-easing/jquery.easing.min.js"></script>
+  <script src="vendor/magnific-popup/jquery.magnific-popup.min.js"></script>
+
+  <!-- Custom scripts for this template -->
+  <script src="js/creative.min.js"></script>
+
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
お問い合わせフォームおよび公表メールアドレス宛ての営業目的の連絡の取扱いを定めたポリシーページを新規追加しました。トップページのContactセクションから導線リンクを設置しています。

## Changes
- `sales-email-policy.html` を新規作成
  - 既存テーマ（Bootstrap / creative.min.css）に合わせたナビ・フッター・スタイルを流用
  - 実際のお問い合わせフォーム項目（「本問い合わせは営業・勧誘目的ではありません」の必須確認）に即した簡潔な8条構成
  - フォーム経由の送信と公表メールアドレス宛ての送信の双方を適用対象として明記
- `index.html` のContactセクションにポリシーページへのリンクを追加

## Test plan
- `index.html` を開き、Contact内「営業目的のご連絡に関するポリシー」リンクから `sales-email-policy.html` へ遷移できること
- ポリシーページのナビ・フッター・スタイルが既存ページと一致して表示されること
- 「トップページへ戻る」ボタンで `index.html` に戻れること

---
Generated with [Claude Code](https://claude.ai/code)