### PR TITLE
サイトデザインをtechnical方向に刷新（AIっぽさの排除）

### DIFF
--- a/src/components/BookCard.astro
+++ b/src/components/BookCard.astro
@@ -8,11 +8,11 @@ const { book: b } = Astro.props;
   href={b.link}
   target="_blank"
   rel="noopener"
-  class="reveal group grid grid-cols-[96px_1fr] gap-5 rounded-card border border-line bg-surface-elevated p-5 shadow-soft transition-all duration-300 hover:-translate-y-1 hover:shadow-card max-sm:grid-cols-[80px_1fr]"
+  class="reveal group grid grid-cols-[96px_1fr] gap-5 rounded-[var(--radius-card)] border border-line bg-surface-elevated p-5 transition-colors duration-200 hover:border-brand max-sm:grid-cols-[80px_1fr]"
 >
   <div
-    class="relative flex aspect-3/4 flex-col justify-between overflow-hidden rounded-md p-2.5 text-white shadow-md"
-    style={`background: linear-gradient(140deg, ${b.accent ?? 'var(--color-brand)'}, color-mix(in srgb, ${b.accent ?? 'var(--color-brand)'} 55%, #000));`}
+    class="relative flex aspect-3/4 flex-col justify-between overflow-hidden rounded-[2px] p-2.5 text-white"
+    style={`background: ${b.accent ?? 'var(--color-brand)'};`}
   >
     <span class="text-[0.5rem] leading-tight opacity-80 line-clamp-3">{b.title}</span>
     {b.volume && <span class="font-en text-[0.6rem] font-bold">{b.volume}</span>}

--- a/src/components/CourseCard.astro
+++ b/src/components/CourseCard.astro
@@ -8,13 +8,13 @@ const { course: c } = Astro.props;
   href={c.link}
   target="_blank"
   rel="noopener"
-  class="reveal group flex flex-col rounded-card border border-line bg-surface-elevated shadow-soft transition-all duration-300 hover:-translate-y-1 hover:shadow-card"
+  class="reveal group flex flex-col rounded-[var(--radius-card)] border border-line bg-surface-elevated transition-colors duration-200 hover:border-brand"
 >
   <div
-    class="flex h-24 items-end justify-between overflow-hidden rounded-t-card p-3 text-white"
-    style={`background: linear-gradient(135deg, ${c.accent ?? 'var(--color-brand)'}, color-mix(in srgb, ${c.accent ?? 'var(--color-brand)'} 55%, #000));`}
+    class="flex h-24 items-end justify-between overflow-hidden rounded-t-[var(--radius-card)] p-3 text-white"
+    style={`background: ${c.accent ?? 'var(--color-brand)'};`}
   >
-    <span class="rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-medium backdrop-blur-sm">{c.category}</span>
+    <span class="rounded-[2px] border border-white/40 px-2 py-0.5 font-en text-[0.7rem] font-medium">{c.category}</span>
     <span class="font-en text-xs font-semibold opacity-90">{c.platform ?? 'Udemy'}</span>
   </div>
   <div class="flex flex-1 flex-col p-4">

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,20 +11,20 @@ const isActive = (href: string) =>
   class="sticky top-0 z-50 border-b border-transparent backdrop-blur-md backdrop-saturate-150 transition-colors"
   style="background: color-mix(in srgb, var(--bg) 82%, transparent);"
 >
-  <div class="container-x flex h-[68px] items-center gap-4">
+  <div class="container-x frame-x flex h-16 items-center gap-4">
     <a href="/" class="font-en text-[1.35rem] font-bold tracking-tight text-ink" aria-label={`${site.brand} トップ`}>
       def<span class="text-brand">.</span><span class="font-medium text-ink-muted">inc</span>
     </a>
 
-    <nav id="primaryNav" class="mx-auto max-lg:fixed max-lg:inset-x-0 max-lg:top-[68px] max-lg:max-h-0 max-lg:overflow-hidden max-lg:border-b max-lg:border-line max-lg:bg-surface max-lg:shadow-[var(--shadow-card)] max-lg:transition-[max-height] max-lg:duration-300 max-lg:mx-0" aria-label="グローバルナビゲーション">
-      <ul id="navList" class="flex list-none gap-1 max-lg:flex-col max-lg:gap-1 max-lg:px-[clamp(1.25rem,5vw,2.5rem)] max-lg:py-5">
+    <nav id="primaryNav" class="mx-auto max-lg:fixed max-lg:inset-x-0 max-lg:top-16 max-lg:max-h-0 max-lg:overflow-hidden max-lg:border-b max-lg:border-line max-lg:bg-surface max-lg:shadow-[var(--shadow-card)] max-lg:transition-[max-height] max-lg:duration-300 max-lg:mx-0" aria-label="グローバルナビゲーション">
+      <ul id="navList" class="flex list-none gap-0.5 max-lg:flex-col max-lg:gap-1 max-lg:px-[clamp(1.25rem,5vw,2.5rem)] max-lg:py-5">
         {
           nav.map((item) => (
             <li>
               <a
                 href={item.href}
                 aria-current={isActive(item.href) ? 'page' : undefined}
-                class="block rounded-full px-[0.9rem] py-2 text-[0.95rem] font-medium text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink aria-[current=page]:bg-brand-soft aria-[current=page]:text-brand max-md:px-4 max-md:py-3 max-md:text-[1.05rem]"
+                class="block rounded-[var(--radius-card)] px-3 py-2 text-[0.9rem] font-medium text-ink-muted transition-colors hover:bg-surface-subtle hover:text-ink aria-[current=page]:bg-brand-soft aria-[current=page]:text-brand max-md:px-4 max-md:py-3 max-md:text-[1.05rem]"
               >
                 {item.label}
               </a>
@@ -41,7 +41,7 @@ const isActive = (href: string) =>
         type="button"
         aria-label="テーマ切替"
         title="ライト / ダーク切替"
-        class="grid h-10 w-10 place-items-center rounded-full border border-line bg-surface-elevated text-ink-muted transition-colors hover:border-brand hover:text-brand"
+        class="grid h-10 w-10 place-items-center rounded-[var(--radius-card)] border border-line bg-surface-elevated text-ink-muted transition-colors hover:border-brand hover:text-brand"
       >
         <svg class="block dark:hidden" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M12 17a5 5 0 1 0 0-10 5 5 0 0 0 0 10Zm0 3a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0v-1a1 1 0 0 1 1-1Zm0-19a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V2a1 1 0 0 1 1-1Zm10 11a1 1 0 0 1-1 1h-1a1 1 0 1 1 0-2h1a1 1 0 0 1 1 1ZM4 12a1 1 0 0 1-1 1H2a1 1 0 1 1 0-2h1a1 1 0 0 1 1 1Zm14.95 6.95a1 1 0 0 1-1.41 0l-.71-.71a1 1 0 0 1 1.41-1.41l.71.71a1 1 0 0 1 0 1.41ZM7.16 7.16a1 1 0 0 1-1.41 0l-.71-.71A1 1 0 0 1 6.45 5.04l.71.71a1 1 0 0 1 0 1.41Zm11.79-2.12a1 1 0 0 1 0 1.41l-.71.71a1 1 0 1 1-1.41-1.41l.71-.71a1 1 0 0 1 1.41 0ZM7.16 16.84a1 1 0 0 1 0 1.41l-.71.71a1 1 0 0 1-1.41-1.41l.71-.71a1 1 0 0 1 1.41 0Z"/></svg>
         <svg class="hidden dark:block" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z"/></svg>
@@ -52,7 +52,7 @@ const isActive = (href: string) =>
         aria-label="メニュー"
         aria-expanded="false"
         aria-controls="navList"
-        class="hidden max-lg:flex h-10 w-10 flex-col items-center justify-center gap-[5px] rounded-[10px] border border-line bg-surface-elevated"
+        class="hidden max-lg:flex h-10 w-10 flex-col items-center justify-center gap-[5px] rounded-[var(--radius-card)] border border-line bg-surface-elevated"
       >
         <span class="h-0.5 w-[18px] bg-ink"></span>
         <span class="h-0.5 w-[18px] bg-ink"></span>

--- a/src/components/OssCard.astro
+++ b/src/components/OssCard.astro
@@ -8,7 +8,7 @@ const { oss } = Astro.props;
   href={oss.link}
   target="_blank"
   rel="noopener"
-  class="reveal group flex flex-col rounded-card border border-line bg-surface-elevated p-5 shadow-soft transition-all duration-300 hover:-translate-y-1 hover:shadow-card"
+  class="reveal group flex flex-col rounded-[var(--radius-card)] border border-line bg-surface-elevated p-5 transition-colors duration-200 hover:border-brand"
 >
   <div class="flex items-center justify-between gap-2">
     <span class="inline-flex items-center gap-1.5 font-en text-sm font-semibold text-ink">

--- a/src/components/WorkCard.astro
+++ b/src/components/WorkCard.astro
@@ -14,17 +14,16 @@ const { href, title, summary, category, tags = [], accent, featured = false } = 
 <a
   href={href}
   class:list={[
-    'reveal group relative flex flex-col overflow-hidden rounded-[var(--radius-card)] border border-line bg-surface-elevated shadow-[var(--shadow-soft)] transition-all duration-300 hover:-translate-y-1 hover:shadow-[var(--shadow-card)]',
+    'reveal group relative flex flex-col overflow-hidden rounded-[var(--radius-card)] border border-line bg-surface-elevated transition-colors duration-200 hover:border-brand',
     featured && 'md:col-span-2',
   ]}
 >
-  <div
-    class="relative flex h-40 items-end overflow-hidden p-5"
-    style={`background: linear-gradient(135deg, ${accent ?? 'var(--color-brand)'} 0%, color-mix(in srgb, ${accent ?? 'var(--color-brand)'} 60%, #000) 100%);`}
-  >
-    <span class="absolute -right-3 -top-4 select-none font-en text-[5.5rem] font-bold leading-none text-white/15">{category}</span>
-    <span class="relative rounded-full bg-white/20 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm">{category}</span>
-    <div class="pointer-events-none absolute inset-0 bg-linear-to-t from-black/25 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
+  <!-- アクセントのシグナルライン -->
+  <span class="h-[3px] w-full" style={`background: ${accent ?? 'var(--color-brand)'};`}></span>
+
+  <div class="relative flex h-24 items-end justify-between border-b border-line bg-surface-subtle p-4">
+    <span class="pointer-events-none absolute -top-2 right-2 select-none font-en text-[3.4rem] font-bold leading-none text-ink-faint/15">{category}</span>
+    <span class="chip relative">{category}</span>
   </div>
 
   <div class="flex flex-1 flex-col p-6">
@@ -35,7 +34,7 @@ const { href, title, summary, category, tags = [], accent, featured = false } = 
         {tags.slice(0, 4).map((t) => (<span class="chip">{t}</span>))}
       </div>
     )}
-    <span class="mt-4 inline-flex items-center gap-1 font-en text-sm font-medium text-brand">
+    <span class="mt-4 inline-flex items-center gap-1.5 font-en text-sm font-medium text-brand">
       詳細を見る
       <svg width="15" height="15" viewBox="0 0 24 24" fill="none" class="transition-transform duration-200 group-hover:translate-x-1"><path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </span>

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -26,12 +26,12 @@ export const company = {
 
 // グローバルナビゲーション
 export const nav = [
-  { label: 'Home', href: '/' },
-  { label: 'Services', href: '/services' },
-  { label: 'Works', href: '/works' },
-  { label: 'Publications', href: '/publications' },
-  { label: 'Courses', href: '/courses' },
+  { label: 'ホーム', href: '/' },
+  { label: 'サービス', href: '/services' },
+  { label: '開発実績', href: '/works' },
+  { label: '出版実績', href: '/publications' },
+  { label: '講座', href: '/courses' },
   { label: 'OSS', href: '/oss' },
-  { label: 'Company', href: '/company' },
-  { label: 'Contact', href: '/contact' },
+  { label: '会社概要', href: '/company' },
+  { label: 'お問い合わせ', href: '/contact' },
 ] as const;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -35,11 +35,11 @@ const canonical = new URL(Astro.url.pathname, site.url).href;
     <meta property="og:locale" content="ja_JP" />
     <meta name="twitter:card" content="summary_large_image" />
 
-    <!-- 英字見出し用フォント -->
+    <!-- 本文用 Inter / 英字・数字・ラベル用 JetBrains Mono -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
 
@@ -63,10 +63,12 @@ const canonical = new URL(Astro.url.pathname, site.url).href;
       >本文へスキップ</a
     >
     <Header />
-    <main id="main">
-      <slot />
-    </main>
-    <Footer />
+    <div class="container-x frame-x px-0!">
+      <main id="main">
+        <slot />
+      </main>
+      <Footer />
+    </div>
 
     <!-- スクロール連動フェードイン -->
     <script is:inline>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,37 +36,12 @@ const services = [
 
 <BaseLayout>
   <!-- Hero -->
-  <section class="relative overflow-hidden">
-    <!-- 背景: 岩手の自然（山並み）モチーフ。/images/hero.jpg を置くと写真が重なります -->
-    <div class="pointer-events-none absolute inset-0 -z-10" aria-hidden="true">
-      <!-- 空のグラデーション -->
-      <div
-        class="absolute inset-0"
-        style="background:
-          radial-gradient(70% 60% at 15% 0%, color-mix(in srgb, var(--color-brand) 20%, transparent), transparent 70%),
-          radial-gradient(55% 55% at 100% 10%, color-mix(in srgb, var(--color-brand) 12%, transparent), transparent 70%);"
-      >
-      </div>
-      <!-- 任意の写真レイヤー（存在すれば表示。無ければ透明） -->
-      <div class="hero-photo absolute inset-0"></div>
-      <!-- 岩手山をイメージした山並みのシルエット -->
-      <svg
-        class="absolute inset-x-0 bottom-0 w-full text-brand"
-        viewBox="0 0 1440 320"
-        preserveAspectRatio="none"
-        style="height: min(46vh, 420px);"
-      >
-        <path fill="currentColor" fill-opacity="0.06"
-          d="M0,220 L240,120 L360,180 L560,60 L760,190 L980,90 L1200,200 L1440,130 L1440,320 L0,320 Z" />
-        <path fill="currentColor" fill-opacity="0.10"
-          d="M0,270 L200,190 L420,250 L640,150 L820,240 L1040,170 L1260,260 L1440,210 L1440,320 L0,320 Z" />
-        <path fill="currentColor" fill-opacity="0.16"
-          d="M0,300 L260,250 L520,290 L780,240 L1020,295 L1280,255 L1440,290 L1440,320 L0,320 Z" />
-      </svg>
-    </div>
-    <div class="container-x flex min-h-[86vh] flex-col justify-center py-24">
+  <section class="relative border-b border-line">
+    <!-- 左端のシグナルライン（アクセント） -->
+    <span class="pointer-events-none absolute left-0 top-0 h-full w-[3px] bg-brand" aria-hidden="true"></span>
+    <div class="container-x flex min-h-[82vh] flex-col justify-center py-24">
       <p class="eyebrow reveal is-visible">{site.tagline}</p>
-      <h1 class="reveal is-visible mt-4 max-w-4xl text-[clamp(2.2rem,6.5vw,4.4rem)] font-bold leading-[1.15] tracking-tight text-ink">
+      <h1 class="reveal is-visible mt-5 max-w-4xl text-[clamp(2.2rem,6.5vw,4.4rem)] font-bold leading-[1.1] tracking-tight text-ink">
         課題を<span class="text-brand">定義</span>し、<br class="max-sm:hidden" />役に立つプロダクトへ。
       </h1>
       <p class="reveal is-visible mt-6 max-w-2xl text-lg text-ink-muted">
@@ -77,18 +52,18 @@ const services = [
         <a class="btn btn-ghost" href="/contact">お問い合わせ</a>
       </div>
 
-      <dl class="reveal mt-16 grid max-w-2xl grid-cols-3 gap-6 border-t border-line pt-8 max-sm:grid-cols-1 max-sm:gap-4">
-        <div>
+      <dl class="reveal mt-16 grid max-w-3xl grid-cols-3 border border-line max-sm:grid-cols-1">
+        <div class="border-r border-line p-5 max-sm:border-b max-sm:border-r-0">
           <dt class="font-en text-3xl font-bold text-ink">2019</dt>
-          <dd class="text-sm text-ink-muted">設立以来の開発実績</dd>
+          <dd class="mt-1 font-en text-xs uppercase tracking-wider text-ink-muted">Since / 設立</dd>
         </div>
-        <div>
+        <div class="border-r border-line p-5 max-sm:border-b max-sm:border-r-0">
           <dt class="font-en text-3xl font-bold text-ink">Web / App</dt>
-          <dd class="text-sm text-ink-muted">両輪での開発体制</dd>
+          <dd class="mt-1 font-en text-xs uppercase tracking-wider text-ink-muted">両輪の開発体制</dd>
         </div>
-        <div>
-          <dt class="font-en text-3xl font-bold text-ink">一貫対応</dt>
-          <dd class="text-sm text-ink-muted">設計から運用まで</dd>
+        <div class="p-5">
+          <dt class="font-en text-3xl font-bold text-ink">End-to-End</dt>
+          <dd class="mt-1 font-en text-xs uppercase tracking-wider text-ink-muted">設計から運用まで</dd>
         </div>
       </dl>
     </div>
@@ -125,8 +100,8 @@ const services = [
 
       <div class="mt-12 grid grid-cols-3 gap-6 max-lg:grid-cols-1">
         {services.map((s) => (
-          <div class="reveal rounded-[var(--radius-card)] border border-line bg-surface-elevated p-7 shadow-[var(--shadow-soft)] transition-transform duration-300 hover:-translate-y-1">
-            <div class="grid h-12 w-12 place-items-center rounded-xl bg-brand-soft text-brand">
+          <div class="reveal rounded-[var(--radius-card)] border border-line bg-surface-elevated p-7 transition-colors duration-200 hover:border-brand">
+            <div class="grid h-12 w-12 place-items-center rounded-[var(--radius-card)] border border-line text-brand">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d={s.icon} stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
             </div>
             <h3 class="mt-5 text-lg font-bold text-ink">{s.title}</h3>
@@ -239,17 +214,16 @@ const services = [
   <!-- CTA -->
   <section class="pb-[clamp(4rem,9vw,7rem)]">
     <div class="container-x">
-      <div
-        class="reveal relative overflow-hidden rounded-[var(--radius-xl2)] px-8 py-16 text-center text-white max-sm:px-5"
-        style="background: linear-gradient(135deg, var(--color-brand), var(--color-brand-strong));"
-      >
-        <h2 class="text-[clamp(1.5rem,3.4vw,2.2rem)] font-bold">プロジェクトのご相談はお気軽に</h2>
-        <p class="mx-auto mt-3 max-w-xl text-white/85">
+      <div class="reveal relative overflow-hidden rounded-[var(--radius-xl2)] border border-line bg-surface-subtle px-8 py-16 text-center max-sm:px-5">
+        <span class="pointer-events-none absolute left-0 top-0 h-full w-[3px] bg-brand" aria-hidden="true"></span>
+        <p class="eyebrow">Contact</p>
+        <h2 class="mt-4 text-[clamp(1.5rem,3.4vw,2.2rem)] font-bold text-ink">プロジェクトのご相談はお気軽に</h2>
+        <p class="mx-auto mt-3 max-w-xl text-ink-muted">
           「こんなことはできる?」という段階でも大丈夫です。まずはお話をお聞かせください。
         </p>
         <div class="mt-8 flex flex-wrap justify-center gap-3">
-          <a class="btn bg-white text-brand-strong hover:bg-white/90" href={site.contactFormUrl} target="_blank" rel="noopener">お問い合わせフォーム</a>
-          <a class="btn border-white/40 text-white hover:border-white" href="/contact">お問い合わせ方法</a>
+          <a class="btn btn-primary" href={site.contactFormUrl} target="_blank" rel="noopener">お問い合わせフォーム</a>
+          <a class="btn btn-ghost" href="/contact">お問い合わせ方法</a>
         </div>
       </div>
     </div>

--- a/src/pages/works/[...slug].astro
+++ b/src/pages/works/[...slug].astro
@@ -25,21 +25,19 @@ const dateStr = data.date.toLocaleDateString('ja-JP', {
 <BaseLayout title={data.title} description={data.summary}>
   <article>
     <!-- ヒーロー -->
-    <header
-      class="relative overflow-hidden text-white"
-      style={`background: linear-gradient(135deg, ${data.accent ?? 'var(--color-brand)'} 0%, color-mix(in srgb, ${data.accent ?? 'var(--color-brand)'} 55%, #000) 100%);`}
-    >
+    <header class="relative border-b border-line bg-surface-subtle">
+      <span class="pointer-events-none absolute left-0 top-0 h-full w-[3px]" style={`background: ${data.accent ?? 'var(--color-brand)'};`} aria-hidden="true"></span>
       <div class="container-x py-[clamp(3.5rem,8vw,6rem)]">
-        <a href="/works" class="inline-flex items-center gap-1.5 text-sm text-white/80 hover:text-white">
+        <a href="/works" class="inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-brand">
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none"><path d="M19 12H5M11 18l-6-6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
           開発実績一覧へ
         </a>
-        <div class="mt-6 flex flex-wrap items-center gap-3 text-sm text-white/85">
-          <span class="rounded-full bg-white/20 px-3 py-1 font-medium backdrop-blur-sm">{data.category}</span>
+        <div class="mt-6 flex flex-wrap items-center gap-3 text-sm text-ink-muted">
+          <span class="chip">{data.category}</span>
           <span class="font-en">{dateStr}</span>
         </div>
-        <h1 class="mt-4 max-w-3xl text-[clamp(1.8rem,4.5vw,3rem)] font-bold leading-tight">{data.title}</h1>
-        <p class="mt-4 max-w-2xl text-lg text-white/90">{data.summary}</p>
+        <h1 class="mt-4 max-w-3xl text-[clamp(1.8rem,4.5vw,3rem)] font-bold leading-tight text-ink">{data.title}</h1>
+        <p class="mt-4 max-w-2xl text-lg text-ink-muted">{data.summary}</p>
       </div>
     </header>
 

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -76,15 +76,17 @@ const categories = [...new Set(works.map((w) => w.data.category))];
 
 <style>
   .filter-chip {
-    padding: 0.5rem 1.05rem;
-    border-radius: 999px;
+    padding: 0.45rem 0.95rem;
+    border-radius: var(--radius-card);
     border: 1px solid var(--border);
     background: var(--bg-elevated);
     color: var(--text-muted);
-    font-size: 0.9rem;
+    font-family: var(--font-en);
+    font-size: 0.82rem;
     font-weight: 500;
+    letter-spacing: 0.02em;
     cursor: pointer;
-    transition: all 0.15s ease;
+    transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
   }
   .filter-chip:hover {
     border-color: var(--color-brand);
@@ -95,6 +97,7 @@ const categories = [...new Set(works.map((w) => w.data.category))];
     border-color: var(--color-brand);
     color: #fff;
   }
+  :root[data-theme="dark"] .filter-chip.is-active { color: #150a06; }
 </style>
 
 <script is:inline>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,50 +5,61 @@
 
 /* =========================================================
    def.inc デザイントークン（Tailwind v4 theme）
+   方向性: Technical / 精密。グリッド前面・等幅ディテール・
+   シグナルオレンジ1色。角ばり・ボーダー基調・グラデ排除。
    ========================================================= */
 @theme {
-  --font-sans: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN",
+  --font-sans: "Inter", "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN",
     "Hiragino Sans", "Noto Sans JP", Meiryo, sans-serif;
-  --font-en: "Space Grotesk", "Helvetica Neue", Arial, sans-serif;
+  /* 英字・数字・ラベルは等幅（技術的なディテール） */
+  --font-en: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
-  /* ブランド */
-  --color-brand: #3b5bdb;
-  --color-brand-strong: #2f4bc0;
-  --color-brand-soft: #edf1ff;
+  /* ブランド（シグナルオレンジ） */
+  --color-brand: #ff5533;
+  --color-brand-strong: #e23c1e;
+  --color-brand-soft: #fdeae5;
 
-  --radius-card: 14px;
-  --radius-xl2: 22px;
+  /* 角ばったフォルム */
+  --radius-card: 4px;
+  --radius-xl2: 6px;
 
-  --shadow-soft: 0 1px 2px rgba(20, 22, 28, 0.04), 0 1px 3px rgba(20, 22, 28, 0.06);
-  --shadow-card: 0 4px 12px rgba(20, 22, 28, 0.06), 0 8px 24px rgba(20, 22, 28, 0.08);
-  --shadow-float: 0 12px 32px rgba(20, 22, 28, 0.10), 0 24px 60px rgba(20, 22, 28, 0.12);
+  /* 影は最小限（枠線で構造を出す） */
+  --shadow-soft: 0 1px 0 rgba(20, 22, 28, 0.04);
+  --shadow-card: 0 1px 0 rgba(20, 22, 28, 0.05);
+  --shadow-float: 0 8px 28px rgba(20, 22, 28, 0.12);
 }
 
 /* セマンティックカラー（ライト / ダークで差し替え） */
 :root {
-  --bg: #ffffff;
-  --bg-subtle: #f6f7fb;
+  --bg: #fbfbfa;
+  --bg-subtle: #f3f3f1;
   --bg-elevated: #ffffff;
-  --border: #e6e8ef;
+  --border: #e2e2df;
+  --grid-line: rgba(20, 22, 28, 0.045);
   --text: #14161c;
   --text-muted: #5b6472;
   --text-faint: #8a92a1;
+  /* ライトはコントラスト確保のため少し濃いオレンジ */
+  --color-brand: #e23c1e;
+  --color-brand-strong: #c22f13;
+  --color-brand-soft: #fdeae5;
   color-scheme: light;
 }
 :root[data-theme="dark"] {
-  --bg: #0c0e14;
-  --bg-subtle: #12151d;
-  --bg-elevated: #161a23;
-  --border: #262b38;
-  --text: #f2f4f8;
-  --text-muted: #a4adbd;
-  --text-faint: #71798a;
-  --color-brand: #6d8bff;
-  --color-brand-strong: #869fff;
-  --color-brand-soft: #171d33;
-  --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.4);
-  --shadow-card: 0 6px 18px rgba(0, 0, 0, 0.45);
-  --shadow-float: 0 16px 44px rgba(0, 0, 0, 0.55);
+  --bg: #0a0b0d;
+  --bg-subtle: #101216;
+  --bg-elevated: #101216;
+  --border: #1e222a;
+  --grid-line: rgba(255, 255, 255, 0.035);
+  --text: #e8ebf0;
+  --text-muted: #838b99;
+  --text-faint: #5f6673;
+  --color-brand: #ff5533;
+  --color-brand-strong: #ff7a5f;
+  --color-brand-soft: #241611;
+  --shadow-soft: 0 1px 0 rgba(0, 0, 0, 0.4);
+  --shadow-card: 0 1px 0 rgba(0, 0, 0, 0.5);
+  --shadow-float: 0 16px 44px rgba(0, 0, 0, 0.6);
   color-scheme: dark;
 }
 
@@ -72,14 +83,21 @@
     background: var(--bg);
     color: var(--text);
     font-family: var(--font-sans);
-    line-height: 1.75;
-    letter-spacing: 0.01em;
+    line-height: 1.7;
+    letter-spacing: 0;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
+    /* 全面の薄いグリッド（技術的な下地） */
+    background-image:
+      linear-gradient(var(--grid-line) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+    background-size: 64px 64px;
+    background-position: -1px -1px;
   }
   h1, h2, h3, h4 {
-    line-height: 1.3;
+    line-height: 1.2;
     font-weight: 700;
+    letter-spacing: -0.02em;
     text-wrap: balance;
   }
   ::selection {
@@ -92,92 +110,84 @@
 }
 
 @layer components {
+  /* 中央カラム。左右ボーダーで工学的な枠を出す */
   .container-x {
     width: 100%;
     max-width: 1120px;
     margin-inline: auto;
     padding-inline: clamp(1.25rem, 5vw, 2.5rem);
   }
+  /* 枠付きにしたい親要素に付与（Header/main のラッパー等） */
+  .frame-x {
+    border-inline: 1px solid var(--border);
+  }
+
   .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
-    padding: 0.85rem 1.6rem;
-    border-radius: 999px;
-    font-weight: 600;
-    font-size: 0.98rem;
+    padding: 0.8rem 1.5rem;
+    border-radius: var(--radius-card);
+    font-family: var(--font-en);
+    font-weight: 500;
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
     border: 1px solid transparent;
     cursor: pointer;
-    transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease,
-      border-color 0.2s ease, color 0.2s ease;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease,
+      filter 0.15s ease;
     white-space: nowrap;
   }
-  .btn:hover { transform: translateY(-2px); }
   .btn-primary {
     background: var(--color-brand);
     color: #fff;
-    box-shadow: var(--shadow-soft);
+    border-color: var(--color-brand);
   }
-  .btn-primary:hover { background: var(--color-brand-strong); color: #fff; box-shadow: var(--shadow-card); }
+  .btn-primary:hover { filter: brightness(1.08); color: #fff; }
+  :root[data-theme="dark"] .btn-primary { color: #150a06; }
   .btn-ghost {
     background: transparent;
     color: var(--text);
     border-color: var(--border);
   }
   .btn-ghost:hover { border-color: var(--color-brand); color: var(--color-brand); }
-  .btn-sm { padding: 0.55rem 1.1rem; font-size: 0.9rem; }
+  .btn-sm { padding: 0.5rem 1rem; font-size: 0.78rem; }
 
+  /* セクション見出しの小ラベル。`//` 付き mono */
   .eyebrow {
     display: inline-block;
     font-family: var(--font-en);
-    font-size: 0.8rem;
-    font-weight: 600;
-    letter-spacing: 0.18em;
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
     color: var(--color-brand);
   }
+  .eyebrow::before {
+    content: "// ";
+    color: var(--text-faint);
+  }
+  /* 角ばったタグ。mono・ボーダー */
   .chip {
     display: inline-block;
-    padding: 0.28rem 0.7rem;
-    border-radius: 999px;
-    font-size: 0.78rem;
+    padding: 0.24rem 0.6rem;
+    border-radius: var(--radius-card);
+    font-family: var(--font-en);
+    font-size: 0.72rem;
     font-weight: 500;
-    background: var(--color-brand-soft);
-    color: var(--color-brand-strong);
+    letter-spacing: 0.02em;
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--text-muted);
   }
-  @media (prefers-reduced-motion: reduce) {
-    .btn:hover { transform: none; }
-  }
-}
-
-/* ヒーローの任意写真レイヤー（/images/hero.jpg を置くと表示） */
-.hero-photo {
-  background-image: linear-gradient(
-      to bottom,
-      color-mix(in srgb, var(--bg) 55%, transparent),
-      color-mix(in srgb, var(--bg) 82%, transparent)
-    ),
-    image-set(url("/images/hero.jpg") 1x);
-  background-size: cover;
-  background-position: center;
-  /* 画像が無い場合はグラデーションのみで自然に見えるよう控えめに */
-  opacity: 0.9;
-}
-:root[data-theme="dark"] .hero-photo {
-  background-image: linear-gradient(
-      to bottom,
-      color-mix(in srgb, var(--bg) 62%, transparent),
-      color-mix(in srgb, var(--bg) 88%, transparent)
-    ),
-    image-set(url("/images/hero.jpg") 1x);
 }
 
 /* スクロール連動フェードイン */
 .reveal {
   opacity: 0;
-  transform: translateY(16px);
-  transition: opacity 0.6s ease, transform 0.6s ease;
+  transform: translateY(12px);
+  transition: opacity 0.5s ease, transform 0.5s ease;
 }
 .reveal.is-visible {
   opacity: 1;


### PR DESCRIPTION
## Summary
インディゴ基調・グラデーション多用・角丸ピルといった「いかにも生成AIが作った」表現を排し、グリッド前面・等幅ディテール・シグナルオレンジ1色の technical / 精密な方向へ全面的に作り直しました。ライト/ダーク両テーマで確認済みです。

## Changes
- **デザイン基盤** (`global.css` / `BaseLayout`): ブランド色を青紫→シグナルオレンジ、角丸14px→4px、影を最小化して枠線で構造化、全面の薄いグリッド背景と左右ボーダー枠(frame-x)を追加。フォントを Space Grotesk → Inter + JetBrains Mono に。`.eyebrow` を `// LABEL` の mono ラベル、`.chip`/`.btn` を角ばり mono に
- **ナビ日本語化** (`site.ts`): Home/Services/... → ホーム/サービス/開発実績/出版実績/講座/OSS/会社概要/お問い合わせ
- **共通コンポーネント** (`Header` / `WorkCard` / `BookCard` / `CourseCard` / `OssCard`): ピル+浮きホバー・グラデ見出しを廃止し、アクセントのシグナルライン+ボーダー基調に統一
- **各ページ** (`index` / `works/[...slug]` / `works/index`): ヒーローの放射状グラデ光・岩手山SVG・グラデCTA箱を撤去、works詳細ヒーローとカテゴリフィルタも技術系に

セマンティックトークン経由で services・company・contact・publications 等の他ページも自動追従。

## Test plan
- `npm run build` 成功（21ページ）
- ライト/ダーク両テーマでトップ・開発実績一覧をヘッドレスブラウザで目視確認

---
Generated with [Claude Code](https://claude.ai/code)