### PR TITLE
トップページに強み・携わってきた分野セクションを追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,6 +32,74 @@ const services = [
     icon: 'M12 3v2m0 14v2m9-9h-2M5 12H3m14.5-6.5-1.4 1.4M7.9 16.1l-1.4 1.4m11 0-1.4-1.4M7.9 7.9 6.5 6.5M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z',
   },
 ];
+
+// 技術スキル・実務経験を、非エンジニアにも伝わる「価値」として言い換えたもの
+const strengths = [
+  {
+    title: '「重い・遅い」を解消します',
+    desc: '3時間かかっていた処理を10分以下に短縮した実績も。表示や処理のスピードを改善し、使う人のストレスとサーバー費用の両方を減らします。',
+    icon: 'M13 2 3 14h7l-1 8 10-12h-7l1-8Z',
+  },
+  {
+    title: '他社が作ったシステムも引き継げます',
+    desc: '複雑で分かりにくいコードでも丁寧に読み解き、不具合の原因を特定して修正します。「作った人と連絡が取れない」システムの改修・保守もお任せください。',
+    icon: 'M11 4a7 7 0 1 0 0 14 7 7 0 0 0 0-14Zm5.5 11.5 4.5 4.5',
+  },
+  {
+    title: 'アクセスが増えても止まらない設計',
+    desc: '10以上の機能が連携する大規模システムの構築・運用経験があります。クラウド(AWS)を活用し、利用者が増えても安定して動く仕組みをつくります。',
+    icon: 'M5 4h14v5H5zM5 15h14v5H5zM8 6.5h.01M8 17.5h.01',
+  },
+  {
+    title: '古くなったシステムの作り替え',
+    desc: '長年使われてきたシステムの刷新や、WordPressから本格的なシステムへの移行など、"作り直し"を数多く手がけてきました。今の課題に合わせて生まれ変わらせます。',
+    icon: 'M21 12a9 9 0 1 1-3-6.7L21 8m0-5v5h-5',
+  },
+  {
+    title: '目的に合った技術を選びます',
+    desc: 'Ruby・Go・React・Next.js・Vue など幅広い技術を使い分けられます。流行っているからではなく、お客様の目的に本当に合った方法を選びます。',
+    icon: 'M12 2 2 7l10 5 10-5-10-5ZM2 17l10 5 10-5M2 12l10 5 10-5',
+  },
+  {
+    title: '技術力の裏付けは、世界への貢献',
+    desc: '世界中で使われるソフトウェア(devise ほか)の改善に貢献しています。日々技術と向き合い続けているからこそ、確かな品質でお応えできます。',
+    icon: 'M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20ZM2 12h20M12 2c3 3 3 17 0 20M12 2c-3 3-3 17 0 20',
+  },
+];
+
+// これまで携わってきた業界・領域（実績の幅を非技術者にも伝える）
+const fields = [
+  {
+    title: '教育・オンライン学習',
+    desc: '日本最大級のオンラインスクールやeラーニングシステム、プログラミング講座の教材制作・講師まで。',
+    icon: 'M22 10 12 5 2 10l10 5 10-5ZM6 12v5c0 1 2.7 3 6 3s6-2 6-3v-5',
+  },
+  {
+    title: '金融・証券',
+    desc: '証券会社の基幹システム開発など、高い正確性と信頼性が求められる領域。',
+    icon: 'M4 20V10m5 10V4m5 16v-7m5 7V8',
+  },
+  {
+    title: 'EC・ショッピング',
+    desc: 'お買い物SNSや産直ECサイトなど、購入体験を支える裏側の仕組みづくり。',
+    icon: 'M6 6h15l-1.6 9H7.5zM6 6 5.2 3H2m5 17a1 1 0 1 0 0-2 1 1 0 0 0 0 2Zm10 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z',
+  },
+  {
+    title: '不動産',
+    desc: 'VRで物件を内覧できるサービスのサーバーサイド開発。',
+    icon: 'M3 11 12 4l9 7M5 10v10h14V10',
+  },
+  {
+    title: '介護・福祉',
+    desc: '介護事業者向けの集客・顧客管理(CRM)システムやコミュニティサイト。',
+    icon: 'M12 21s-7-4.35-9.5-8.5C1 9 3 5 6.5 5 9 5 12 8 12 8s3-3 5.5-3C21 5 23 9 21.5 12.5 19 16.65 12 21 12 21Z',
+  },
+  {
+    title: '会員・コミュニティ',
+    desc: '退職者向け会員サイトのリニューアルなど、人がつながる場のシステム。',
+    icon: 'M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2M9 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm13 10v-2a4 4 0 0 0-3-3.87M16 3.13A4 4 0 0 1 16 11',
+  },
+];
 ---
 
 <BaseLayout>
@@ -89,6 +157,29 @@ const services = [
     </div>
   </section>
 
+  <!-- Strengths -->
+  <section class="border-t border-line py-[clamp(4rem,9vw,7rem)]">
+    <div class="container-x">
+      <div class="reveal max-w-2xl">
+        <p class="eyebrow">Strengths</p>
+        <h2 class="mt-3 text-[clamp(1.6rem,3.6vw,2.4rem)] font-bold text-ink">私たちの強み</h2>
+        <p class="mt-3 text-ink-muted">数多くの開発現場で培った経験を、お客様の課題解決にそのまま活かします。</p>
+      </div>
+
+      <div class="mt-12 grid grid-cols-3 gap-6 max-lg:grid-cols-2 max-sm:grid-cols-1">
+        {strengths.map((s) => (
+          <div class="reveal rounded-[var(--radius-card)] border border-line bg-surface-elevated p-7 transition-colors duration-200 hover:border-brand">
+            <div class="grid h-12 w-12 place-items-center rounded-[var(--radius-card)] border border-line text-brand">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d={s.icon} stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+            <h3 class="mt-5 text-lg font-bold text-ink">{s.title}</h3>
+            <p class="mt-2 mb-0 text-[0.93rem] text-ink-muted">{s.desc}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
   <!-- Services -->
   <section class="border-y border-line bg-surface-subtle py-[clamp(4rem,9vw,7rem)]">
     <div class="container-x">
@@ -116,8 +207,33 @@ const services = [
     </div>
   </section>
 
-  <!-- Works -->
+  <!-- Fields -->
   <section class="py-[clamp(4rem,9vw,7rem)]">
+    <div class="container-x">
+      <div class="reveal max-w-2xl">
+        <p class="eyebrow">Fields</p>
+        <h2 class="mt-3 text-[clamp(1.6rem,3.6vw,2.4rem)] font-bold text-ink">携わってきた分野</h2>
+        <p class="mt-3 text-ink-muted">教育から金融、EC、不動産まで。さまざまな業界のシステム開発に携わってきました。</p>
+      </div>
+
+      <div class="mt-12 grid grid-cols-3 gap-6 max-lg:grid-cols-2 max-sm:grid-cols-1">
+        {fields.map((f) => (
+          <div class="reveal flex items-start gap-4 rounded-[var(--radius-card)] border border-line bg-surface-elevated p-6 transition-colors duration-200 hover:border-brand">
+            <div class="grid h-11 w-11 shrink-0 place-items-center rounded-[var(--radius-card)] border border-line text-brand">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none"><path d={f.icon} stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </div>
+            <div>
+              <h3 class="text-base font-bold text-ink">{f.title}</h3>
+              <p class="mt-1.5 mb-0 text-[0.9rem] text-ink-muted">{f.desc}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Works -->
+  <section class="border-t border-line py-[clamp(4rem,9vw,7rem)]">
     <div class="container-x">
       <div class="reveal flex items-end justify-between gap-4">
         <div class="max-w-2xl">


### PR DESCRIPTION
## Summary
トップページに、技術スキル・実務経験・プロジェクト実績を非技術者にも伝わる「価値」として言い換えた2つのセクションを追加しました。

## Changes
- **私たちの強み（Strengths）** を About セクションの直後に追加
  - パフォーマンス改善（3時間→10分の実績）、既存システムの引き継ぎ、大規模・安定設計、システムの作り替え、幅広い技術選定、OSS貢献 の6枚のカード
- **携わってきた分野（Fields）** を Works セクションの直前に追加
  - プロジェクト実績を業界カテゴリに集約（教育・オンライン学習／金融・証券／EC・ショッピング／不動産／介護・福祉／会員・コミュニティ）
- 既存のデザイントークン・ユーティリティクラス（eyebrow / reveal / border-line / brand アクセント）に準拠

## Test plan
- `npm run build` が成功することを確認済み
- `npm run dev` でトップページの表示・レスポンシブ・ダークモードを確認

---
Generated with [Claude Code](https://claude.ai/code)